### PR TITLE
bug-fix: use GITHUB_TOKEN and grant write permissions for Pages deploy

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -1,4 +1,6 @@
 name: Build and Deploy
+permissions:
+  contents: write
 on: 
   push:
     branches:
@@ -20,5 +22,6 @@ jobs:
       - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@4.1.5
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           branch: gh-pages # The branch the action should deploy to.
           folder: dist # The folder the action should deploy.


### PR DESCRIPTION
# Description
This PR grants write permissions for Github Pages to deploy.

# Testing
N/A

# DB changes
N/A

# Sys Changes
N/A

# Additional Comments
N/A