### PR TITLE
fix-map: used ts ignore to ignore a warning that causes error in vite build

### DIFF
--- a/src/components/SchoolMap.tsx
+++ b/src/components/SchoolMap.tsx
@@ -5,6 +5,7 @@ export default function SchoolMap({lat, lng}: {lat: number; lng: number; }) {
   const rawKey = import.meta.env.VITE_GOOGLE_MAPS_KEY;
 
   if (typeof rawKey !== "string" || rawKey === "") {
+    // @ts-ignore TS2590: Chakra’s Text children type is too big for TS to infer here
     return <Text color="red.500">Missing Google Maps API key</Text>;
   }
 


### PR DESCRIPTION
# Description
This PR solves the error causing vite build to fail using ts-ignore flag.

# Testing
N/A

# DB changes
N/A

# Sys Changes
N/A

# Additional Comments
N/A